### PR TITLE
gitコマンドがあるのにメッセージが出る

### DIFF
--- a/plugin/openbrowser/github.vim
+++ b/plugin/openbrowser/github.vim
@@ -19,7 +19,7 @@ function! s:error(msg)
     echohl None
 endfunction
 
-if executable('git')
+if !executable('git')
     call s:error('Please install git in your PATH.')
     finish
 endif


### PR DESCRIPTION
https://github.com/tyru/open-browser-github.vim/blob/master/plugin/openbrowser/github.vim#L22

たぶんこちらの変更でだと思うのですが、`git`コマンドが`executable()`でtrueなのに

``` sh
Please install git in your PATH.
```

とメッセージがVimの起動時に出てしまいました。
