### PR TITLE
Support ghq(https://github.com/motemen/ghq)

### DIFF
--- a/autoload/openbrowser/github.vim
+++ b/autoload/openbrowser/github.vim
@@ -189,7 +189,7 @@ function! s:parse_github_remote_url(github_host)
     let host_re = substitute(a:github_host, '\.', '\.', 'g')
     let gh_host_re = 'github\.com'
 
-    let ssh_re_fmt = 'git@%s:\([^/]\+\)/\([^/]\+\)\s'
+    let ssh_re_fmt = 'git@%s.\([^/]\+\)/\([^/]\+\)\s'
     let git_re_fmt = 'git://%s/\([^/]\+\)/\([^/]\+\)\s'
     let https_re_fmt = 'https\?://%s/\([^/]\+\)/\([^/]\+\)\s'
 


### PR DESCRIPTION
[ghq](https://github.com/motemen/ghq)を利用してcloneしてきた場合、`remote.origin.url`が`ssh://git@github.com/`から始まるものになり、`:OpenGithubFile`が

```
openbrowser/github: Could not detect repos user.
```

と出て、利用出来ないため対応しました
