### PR TITLE
Make :OpenGitHubIssue and :OpenGitHubPullReq look under the cursor

### DIFF
--- a/autoload/openbrowser/github.vim
+++ b/autoload/openbrowser/github.vim
@@ -180,13 +180,23 @@ function! s:cmd_open_url(args, type)
     " Both '#1' and '1' are supported.
     let number = matchstr(get(a:args, 0, ''), '^#\?\zs\d\+\ze$')
 
+    " If the issue number is omitted, the index of argument of repository will
+    " become 0 (a:args[0]), otherwise 1 (a:args[1])
+    let repos_arg_index = number == '' ? 0 : 1
+
     if a:type ==# s:TYPE_ISSUE
+        if number ==# ''
+            let number = s:issue_number_under_cursor(getline('.'), col('.'))
+        endif
         if number !=# ''
             let path = 'issues/' . number
         else
             let path = 'issues'
         endif
     elseif a:type ==# s:TYPE_PULLREQ
+        if number ==# ''
+            let number = s:issue_number_under_cursor(getline('.'), col('.'))
+        endif
         if number !=# ''
             let path = 'pull/' . number
         else
@@ -201,10 +211,6 @@ function! s:cmd_open_url(args, type)
     else
 
         let github_host = s:get_github_host()
-
-        " If the issue number is omitted, the index of argument of repository will
-        " become 0 (a:args[0]), otherwise 1 (a:args[1])
-        let repos_arg_index = number == '' ? 0 : 1
 
         " If the argument of repository was given and valid format,
         " set user and repos.
@@ -259,6 +265,21 @@ function! s:call_with_temp_dir(dir, funcname, args)
             execute (haslocaldir ? 'lcd' : 'cd') cwd
         endif
     endtry
+endfunction
+
+function! s:issue_number_under_cursor(line, col)
+    let [number, start, end] = matchstrpos(a:line, '#\d\+')
+    if number ==# ''
+        return ''
+    endif
+
+    let idx = a:col - 1
+    if idx < start || end < idx
+        return ''
+    endif
+
+    " Emit first '#'
+    return number[1:]
 endfunction
 
 function! s:parse_github_remote_url(github_host)


### PR DESCRIPTION
カーソル下が `#数字` だった場合，その issue（または pull request）番号のページを開くようにしました．コード内に修正した該当 issue 番号が書いてあることが結構あって，そこを直接開きたいことが結構あったので実装しました．番号からだけでは issue か pull request か判断できないのですが，GitHub 側で適宜リダイレクトされると思うので良いかなと思っています．

一応手元では動作確認済みです with 8.0-329 on macOS 10.12