### PR TITLE
Do not depend on openbrowser's global variable

### DIFF
--- a/autoload/openbrowser/github.vim
+++ b/autoload/openbrowser/github.vim
@@ -394,7 +394,8 @@ endfunction
 
 
 
-if g:openbrowser_use_vimproc
+" Default value is 1 (use vimproc)
+if get(g:, 'openbrowser_use_vimproc', 1)
 \       && globpath(&rtp, 'autoload/vimproc.vim') !=# ''
   function! s:git(...) abort
     return s:trim(vimproc#system(['git'] + a:000))


### PR DESCRIPTION
Fix #26

The variable is defined at runtime of open-browser.vim.
Do not assume open-browser is loaded before autoload/openbrowser/github.vim is loaded.