### PR TITLE
uses openbrowser_github_select_current_line as a flag

### DIFF
--- a/autoload/openbrowser/github.vim
+++ b/autoload/openbrowser/github.vim
@@ -24,7 +24,11 @@ endfunction
 
 " Opens a specific file in github.com repository.
 function! s:cmd_file(args, rangegiven, firstlnum, lastlnum) abort
-  let rangegiven = get(g:, 'openbrowser_github_select_current_line', a:rangegiven)
+  if get(g:, 'openbrowser_github_select_current_line', v:false)
+    let rangegiven = a:rangegiven
+  else
+    let rangegiven = 0
+  endif
   let [path, err] = s:parse_cmd_file_args(a:args, rangegiven, a:firstlnum, a:lastlnum)
   if err !=# ''
     call s:error(err)


### PR DESCRIPTION
`g:openbrowser_github_select_current_line` is looks like a flag in the doc.
But now, it overlaps `rangegiven` in the `s:cmd_file`.

Since it being defined in `plugin/openbrowser/github.vim`,
`rangegiven` always becomes zero.

This PR may fixes #32.
