### PR TITLE
Ignore generated docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
This PR adds ignoring generated tags. It will be useful for users who use the native package manager and update plugins through `git`. The same approach used in [open-browser.vim](https://github.com/tyru/open-browser.vim).