### PR TITLE
Fix openbrowser_github_select_current_line on NeoVim

### DIFF
--- a/autoload/openbrowser/github.vim
+++ b/autoload/openbrowser/github.vim
@@ -19,7 +19,8 @@ endfunction
 function! openbrowser#github#file(args, rangegiven, firstlnum, lastlnum) abort
   let file = s:resolve(expand(get(a:args, 0, '%')))
   let worktree = s:lookup_git_worktree(file)
-  call s:call_with_temp_dir(worktree, 's:cmd_file', [a:args, a:rangegiven, a:firstlnum, a:lastlnum])
+  let lastlnum = max([a:firstlnum, a:lastlnum]) " a:firstlnum could be bigger in NeoVim
+  call s:call_with_temp_dir(worktree, 's:cmd_file', [a:args, a:rangegiven, a:firstlnum, lastlnum])
 endfunction
 
 " Opens a specific file in github.com repository.


### PR DESCRIPTION
## Problem
When you have `let g:openbrowser_github_select_current_line = 1` and execute `:OpenGithubFile` on line 10 without selecting a range, Vim 8.1 opens a url ending with `#L10`. However, NeoVim 0.4.3 opens one ending with `#L10-L1`, while I want to show `#L10` like Vim.

## Solution
That is because NeoVim sets `line1=10, line2=1` whereas Vim sets `line1=10, line2=10`. If we use `max([line1, line2])` as `lastlnum`, it will work on NeoVim as well.

Maybe this could be a bug of NeoVim, but it'd be nice if we can fix the behavior for the current NeoVim version.