### PR TITLE
Add a new g:openbrowser_github_always_use_upstream_commit_hash option

### DIFF
--- a/autoload/openbrowser/github.vim
+++ b/autoload/openbrowser/github.vim
@@ -65,7 +65,11 @@ function! s:parse_cmd_file_args(args, rangegiven, firstlnum, lastlnum) abort
   if g:openbrowser_github_always_used_branch !=# ''
     let branch = g:openbrowser_github_always_used_branch
   elseif g:openbrowser_github_always_use_commit_hash
-    let branch = s:git('rev-parse', 'HEAD')
+    if g:openbrowser_github_always_use_upstream_commit_hash
+      let branch = s:git('rev-parse', 'HEAD@{upstream}')
+    else
+      let branch = s:git('rev-parse', 'HEAD')
+    endif
   else
     " When working tree is detached state,
     " branch becomes commit hash.

--- a/doc/openbrowser-github.txt
+++ b/doc/openbrowser-github.txt
@@ -92,6 +92,14 @@ g:openbrowser_github_always_use_commit_hash
 	with a current branch's latest file.
 	ex) https://github.com/tyru/open-browser.vim/blob/master/autoload/openbrowser.vim
 
+					*g:openbrowser_github_always_use_upstream_commit_hash*
+g:openbrowser_github_always_use_upstream_commit_hash
+							(Default: 0)
+	If this variable is non-zero value, |openbrowser-github| always opens a
+    URL with a current upstream commit hash. This is useful if you usually have
+    local commits which are not yet pushed, and most of the upstream and local
+    code is unchanged.
+
 					*g:openbrowser_github_url_exists_check*
 g:openbrowser_github_url_exists_check
 							(Default: "yes")

--- a/plugin/openbrowser/github.vim
+++ b/plugin/openbrowser/github.vim
@@ -34,6 +34,9 @@ endif
 if !exists('g:openbrowser_github_always_use_commit_hash')
   let g:openbrowser_github_always_use_commit_hash = 1
 endif
+if !exists('g:openbrowser_github_always_use_upstream_commit_hash')
+  let g:openbrowser_github_always_use_upstream_commit_hash = 0
+endif
 if !exists('g:openbrowser_github_url_exists_check')
   let g:openbrowser_github_url_exists_check = 'yes'
 endif


### PR DESCRIPTION
I regularly hit 404 errors on GitHub with OpenGithubFile because I have some local commits around, which are not yet pushed anywhere.

The benefit of linking to commits is that line references work later (when the code gets changed on a branch), so that's wanted. At the same time, some worflows mean that you typically have small local commits, so even if the line numbers work give correct results, the opened link doesn't work, as it tries to look up a local hash, not the upstream hash.

Fix the problem by adding a new 'always_use_upstream_commit_hash' option (disabled by default), so in case it's known that the line numbers will work in practice (consider a large codebase, and only a few, small local commits), then this way we can get working URLs.

This is disabled by default, since in case there are many large commits and the inspected part of the file is different locally vs upstream, then this will give garbage results, so it's not safe in general.